### PR TITLE
Pin cryptography to <38.0.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [packages]
 aiocontextvars = "==0.2.2"
-cryptography = "==37.0.4"
+cryptography = "<38.0.0"  # https://github.com/SecurityInnovation/PGPy/issues/402
 fastapi = "==0.85.0"
 gunicorn = "==20.1.0"
 honcho = "==1.1.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "eab669ddd657a0b6f78dc61648402cefe9361ad9c1c45f148105b94f5dd0dc2b"
+            "sha256": "37fbffe807e9d1a59d816438f23a7bd492daaded7a78fb51ddc41a1f0ffdd9e5"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
PGPy is not yet compatible with cryptography >= 38.0.0

https://github.com/SecurityInnovation/PGPy/issues/402